### PR TITLE
Fix CPU device support and remove FFmpeg FPS cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Run the script:
 python inference_demo.py --input_path <your_input> --text_prompts <text_prompt 1> <text_prompt 2>
 ```
 
+💡 Tip: If you don't have a GPU or prefer to run on CPU, add the --device "cpu" flag
+
 Examples:
 ```
 # On a single image

--- a/models/samwise.py
+++ b/models/samwise.py
@@ -59,6 +59,8 @@ class SAMWISE(nn.Module):
         self.cme_decision_window = args.cme_decision_window # minimum number of frames between each CME application
         self.switch_mem = args.switch_mem
 
+        self.device = args.device
+
 
     def forward(self, samples, captions, targets):
         """ The forward expects a NestedTensor, which consists of:
@@ -143,8 +145,8 @@ class SAMWISE(nn.Module):
 
     def preprocess_text_features(self, captions):
         batch_encoding_text = self.tokenizer(captions, add_special_tokens=True, padding=True)
-        input_ids = torch.tensor(batch_encoding_text['input_ids']).cuda()
-        attention_mask = torch.tensor(batch_encoding_text['attention_mask']).eq(0).cuda()
+        input_ids = torch.tensor(batch_encoding_text['input_ids']).to(self.device)
+        attention_mask = torch.tensor(batch_encoding_text['attention_mask']).eq(0).to(self.device)
         text_encoder = self.text_encoder.model.encoder.sentence_encoder
         has_pads = (torch.tensor(input_ids.device.type == "xla") or attention_mask.any())
         x, encoder_embedding = text_encoder.forward_embedding(input_ids, None)


### PR DESCRIPTION
Hi,

I tested the inference script and noticed a few issues:

-     There was a hardcoded cap at 10 FPS when extracting video frames.
-     Running the script on CPU caused several problems, which I’ve fixed to ensure smoother execution.
-     I also automated the checkpoint downloading process to simplify inference setup.

Additionally, I had a question:
Why are different models used depending on the data type? Specifically:

-     For images, the script loads pretrained_model.pth
-     For videos, it uses final_model_mevis.pth

Is there a reason for this difference?